### PR TITLE
Improve normalization edge cases

### DIFF
--- a/src/methods/wpm.py
+++ b/src/methods/wpm.py
@@ -32,11 +32,23 @@ class WPM(MCDMMethod):
         n_alternatives = len(self.alternatives)
 
         # Step 1: Handle cost criteria by taking reciprocals (convert to benefit)
-        processed_matrix = matrix.copy()
+        processed_matrix = matrix.copy().astype(float)
         for i, (col, ctype) in enumerate(zip(matrix.columns, self.criterion_types)):
+            col_values = matrix[col].astype(float)
+
+            # Ensure all values are positive to avoid invalid powers or divisions
+            if np.any(col_values <= 0):
+                positives = col_values[col_values > 0]
+                if len(positives) > 0:
+                    offset = positives.min() / 1000.0
+                else:
+                    offset = abs(col_values.min()) + 1e-6
+                col_values = col_values + offset
+
             if ctype == 'cost':
-                # For cost criteria, use reciprocal (1/x) to convert to benefit
-                processed_matrix[col] = 1.0 / matrix[col]
+                processed_matrix[col] = 1.0 / col_values
+            else:
+                processed_matrix[col] = col_values
 
         # Step 2: Calculate pairwise comparison ratios
         # Create a matrix to store P(Ak/Al) values


### PR DESCRIPTION
## Summary
- handle zero and constant values in vector normalization
- add regression tests for constant columns and zero values
- handle zero cost values in WPM
- add regression test for zero-cost WPM matrix
- improve cost handling in vector normalization of cost criteria
- test negative cost values in vector normalization
- fix WPM to shift non-positive values before reciprocals

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853ccecdca08321a0d9c94a68a41d0d